### PR TITLE
Fix x509 certificate KeyUsage validation for Apple App Attest

### DIFF
--- a/attestation/attestation.go
+++ b/attestation/attestation.go
@@ -152,10 +152,15 @@ func verifyAttestation(att AttestationObject, clientDataHash, keyID []byte) ([]b
 	}
 
 	// Create verification options.
+	// Fix: Add KeyUsages to accept certificates with any ExtKeyUsage
+	// This fixes the "x509: certificate specifies an incompatible key usage" error
+	// that occurs with Apple's new App Attest certificates (since Jan 5, 2026)
+	// which have ExtKeyUsage extensions without ServerAuth.
 	verifyOptions := x509.VerifyOptions{
 		Roots:         roots,
 		Intermediates: intermediates,
 		CurrentTime:   TimeNow(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
 	// 1. Verify that the x5c array contains the intermediate and leaf certificates for App Attest,


### PR DESCRIPTION
Apple rotated their App Attest certificates on Jan 5, 2026, adding ExtKeyUsage extensions without ServerAuth. This caused certificate validation to fail with "x509: certificate specifies an incompatible key usage" error.

Fix: Add KeyUsages field to x509.VerifyOptions with ExtKeyUsageAny to accept certificates with any ExtKeyUsage, as App Attest certificates are for attestation/code signing, not TLS server authentication.

This aligns with Apple's App Attest specification where certificates are not required to have ServerAuth ExtKeyUsage.

Fixes: Certificate validation failures since Jan 5, 2026